### PR TITLE
Fix configuration flag usages

### DIFF
--- a/EpiserverRedirects/Configuration/DependencyInjectionConfig.cs
+++ b/EpiserverRedirects/Configuration/DependencyInjectionConfig.cs
@@ -31,7 +31,7 @@ namespace Forte.EpiserverRedirects.Configuration
 
         private void RegisterRedirectResolver(ServiceConfigurationContext context)
         {
-            if (Configuration.IsAllRedirectsCacheEnabled)
+            if (Configuration.IsUrlRedirectCacheEnabled)
             {
                 context.Services.AddTransient<ICache<IRedirect>, Cache<IRedirect>>();
                 context.Services.AddTransient<IRedirectRuleResolver>(
@@ -45,7 +45,7 @@ namespace Forte.EpiserverRedirects.Configuration
 
         private static void RegisterRepository(ServiceConfigurationContext context)
         {
-            if (Configuration.IsUrlRedirectCacheEnabled)
+            if (Configuration.IsAllRedirectsCacheEnabled)
             {
                 context.Services.AddTransient<ICache<RedirectRule[]>, Cache<RedirectRule[]>>();
                 context.Services.AddTransient<IRedirectRuleRepository>(c =>


### PR DESCRIPTION
Currently there's a mix in configuration. 

`IsUrlRedirectCacheEnabled` is related to `IRedirectRuleRepository` and it supposed to be related to `IRedirectRuleResolver`
`IsAllRedirectsCacheEnabled` is related to `IRedirectRuleResolver` and it is supposed to be related to `IRedirectRuleRepository`