### PR TITLE
Enforce unique Rules (Old Urls)

### DIFF
--- a/AlloyDemoKit/modules/_protected/Forte.EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.html
+++ b/AlloyDemoKit/modules/_protected/Forte.EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.html
@@ -38,16 +38,18 @@
                     <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="deleteButton" type="button">Delete</button>
                     <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="refreshButton" type="button">Refresh</button>
                     <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="clearAllButton" type="button">Clear all</button>
-<!--                    <div class="epi-formArea">
-                        <label>Simulate Wildcard redirect:</label>
-                        <input class="form-input" type="text" name="simulateOldUrl"
-                               data-dojo-props="intermediateChanges:true"
-                               data-dojo-type="dijit/form/TextBox"
-                               placeHolder="Old Url"
-                               data-dojo-attach-point="simulateOldUrlTextBox" id="simulateOldUrl" />
-                        <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateFindButton" type="button">Find</button>
-                        <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateResetButton" type="button">Reset</button>
-                    </div>-->
+                    <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="removeDuplicatesButton" type="button">Remove duplicates</button>
+                    <span name="removeDuplicatesStatus" value="" data-dojo-attach-point="removeDuplicatesStatus"></span>
+                    <!--                    <div class="epi-formArea">
+                                            <label>Simulate Wildcard redirect:</label>
+                                            <input class="form-input" type="text" name="simulateOldUrl"
+                                                   data-dojo-props="intermediateChanges:true"
+                                                   data-dojo-type="dijit/form/TextBox"
+                                                   placeHolder="Old Url"
+                                                   data-dojo-attach-point="simulateOldUrlTextBox" id="simulateOldUrl" />
+                                            <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateFindButton" type="button">Find</button>
+                                            <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateResetButton" type="button">Reset</button>
+                                        </div>-->
                     <div class="url-redirect-grid" data-dojo-type="redirectsMenu-grid/RedirectsMenuGrid" data-dojo-attach-point="redirectsMenuGrid">
                     </div>
                 </div>

--- a/AlloyDemoKit/modules/_protected/Forte.EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.js
+++ b/AlloyDemoKit/modules/_protected/Forte.EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.js
@@ -58,6 +58,7 @@ define("redirectsMenu/RedirectsMenu", [
                 on(this.deleteButton, "click", this._onDeleteClick.bind(this));
                 on(this.refreshButton, "click", this._refreshView.bind(this));
                 on(this.clearAllButton, "click", this._onClearAllClick.bind(this));
+                on(this.removeDuplicatesButton, "click", this._onRemoveDuplicatesClick.bind(this));
                 /*on(this.simulateFindButton, "click", this._onSimulateFindClick.bind(this));
                 on(this.simulateResetButton, "click", this._onSimulateResetClick.bind(this));*/
                 on(this.uploadFormSubmit, "click", this._onImportSubmit.bind(this));
@@ -127,6 +128,17 @@ define("redirectsMenu/RedirectsMenu", [
             _onClearAllClick: function() {
                 if (window.confirm("Do you really want to clear all redirect rules?")) {
                     this.redirectsMenuViewModel.clearRedirectRules().then((r) => this._refreshView());
+                }
+            },
+
+            _onRemoveDuplicatesClick: function() {
+                if (window.confirm("Do you really want to remove all duplicates?")) {
+                    var removeDuplicatesStatus = this.removeDuplicatesStatus;
+                    removeDuplicatesStatus.innerText = "Removing duplicates...";
+                    this.redirectsMenuViewModel.removeDuplicateRules().then((r) => {
+                        removeDuplicatesStatus.innerText = "Duplicates removed.";
+                        this._refreshView()
+                    });
                 }
             },
 

--- a/AlloyDemoKit/modules/_protected/Forte.EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenuViewModel.js
+++ b/AlloyDemoKit/modules/_protected/Forte.EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenuViewModel.js
@@ -6,6 +6,8 @@
 ], function (declare, Stateful, dependency) {
 
     var clearAllGuid = "00000000-0000-0000-0000-000000000000";
+    var clearAllDuplicatesGuid = "00000000-0000-0000-0000-000000000001";
+
     return declare([Stateful], {
         store: null,
 
@@ -64,6 +66,10 @@
         
         clearRedirectRules: function() {
             return this.store.remove(clearAllGuid);
+        },
+
+        removeDuplicateRules: function () {
+            return this.store.remove(clearAllDuplicatesGuid);
         }
     });
 });

--- a/EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.html
+++ b/EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.html
@@ -38,16 +38,18 @@
                     <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="deleteButton" type="button">Delete</button>
                     <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="refreshButton" type="button">Refresh</button>
                     <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="clearAllButton" type="button">Clear all</button>
-<!--                    <div class="epi-formArea">
-                        <label>Simulate Wildcard redirect:</label>
-                        <input class="form-input" type="text" name="simulateOldUrl"
-                               data-dojo-props="intermediateChanges:true"
-                               data-dojo-type="dijit/form/TextBox"
-                               placeHolder="Old Url"
-                               data-dojo-attach-point="simulateOldUrlTextBox" id="simulateOldUrl" />
-                        <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateFindButton" type="button">Find</button>
-                        <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateResetButton" type="button">Reset</button>
-                    </div>-->
+                    <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="removeDuplicatesButton" type="button">Remove duplicates</button>
+                    <span name="removeDuplicatesStatus" value="" data-dojo-attach-point="removeDuplicatesStatus"></span>
+                    <!--                    <div class="epi-formArea">
+                                            <label>Simulate Wildcard redirect:</label>
+                                            <input class="form-input" type="text" name="simulateOldUrl"
+                                                   data-dojo-props="intermediateChanges:true"
+                                                   data-dojo-type="dijit/form/TextBox"
+                                                   placeHolder="Old Url"
+                                                   data-dojo-attach-point="simulateOldUrlTextBox" id="simulateOldUrl" />
+                                            <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateFindButton" type="button">Find</button>
+                                            <button data-dojo-type="dijit/form/Button" data-dojo-attach-point="simulateResetButton" type="button">Reset</button>
+                                        </div>-->
                     <div class="url-redirect-grid" data-dojo-type="redirectsMenu-grid/RedirectsMenuGrid" data-dojo-attach-point="redirectsMenuGrid">
                     </div>
                 </div>

--- a/EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.js
+++ b/EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenu.js
@@ -58,6 +58,7 @@ define("redirectsMenu/RedirectsMenu", [
                 on(this.deleteButton, "click", this._onDeleteClick.bind(this));
                 on(this.refreshButton, "click", this._refreshView.bind(this));
                 on(this.clearAllButton, "click", this._onClearAllClick.bind(this));
+                on(this.removeDuplicatesButton, "click", this._onRemoveDuplicatesClick.bind(this));
                 /*on(this.simulateFindButton, "click", this._onSimulateFindClick.bind(this));
                 on(this.simulateResetButton, "click", this._onSimulateResetClick.bind(this));*/
                 on(this.uploadFormSubmit, "click", this._onImportSubmit.bind(this));
@@ -127,6 +128,17 @@ define("redirectsMenu/RedirectsMenu", [
             _onClearAllClick: function() {
                 if (window.confirm("Do you really want to clear all redirect rules?")) {
                     this.redirectsMenuViewModel.clearRedirectRules().then((r) => this._refreshView());
+                }
+            },
+
+            _onRemoveDuplicatesClick: function() {
+                if (window.confirm("Do you really want to remove all duplicates?")) {
+                    var removeDuplicatesStatus = this.removeDuplicatesStatus;
+                    removeDuplicatesStatus.innerText = "Removing duplicates...";
+                    this.redirectsMenuViewModel.removeDuplicateRules().then((r) => {
+                        removeDuplicatesStatus.innerText = "Duplicates removed.";
+                        this._refreshView()
+                    });
                 }
             },
 

--- a/EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenuViewModel.js
+++ b/EpiserverRedirects/ClientResources/RedirectsMenu/RedirectsMenuViewModel.js
@@ -6,6 +6,8 @@
 ], function (declare, Stateful, dependency) {
 
     var clearAllGuid = "00000000-0000-0000-0000-000000000000";
+    var clearAllDuplicatesGuid = "00000000-0000-0000-0000-000000000001";
+
     return declare([Stateful], {
         store: null,
 
@@ -64,6 +66,10 @@
         
         clearRedirectRules: function() {
             return this.store.remove(clearAllGuid);
+        },
+
+        removeDuplicateRules: function () {
+            return this.store.remove(clearAllDuplicatesGuid);
         }
     });
 });

--- a/EpiserverRedirects/Menu/RedirectRuleStore.cs
+++ b/EpiserverRedirects/Menu/RedirectRuleStore.cs
@@ -15,6 +15,7 @@ namespace Forte.EpiserverRedirects.Menu
         private readonly IRedirectRuleRepository _redirectRuleRepository;
         private readonly IRedirectRuleMapper _redirectRuleMapper;
         private readonly Guid _clearAllGuid = Guid.Parse("00000000-0000-0000-0000-000000000000");
+        private readonly Guid _clearAllDuplicatesGuid = Guid.Parse("00000000-0000-0000-0000-000000000001");
 
         public RedirectRuleStore(IRedirectRuleRepository redirectRuleRepository, IRedirectRuleMapper redirectRuleMapper)
         {
@@ -77,9 +78,17 @@ namespace Forte.EpiserverRedirects.Menu
         [HttpDelete]
         public ActionResult Delete(Guid id)
         {
-            var deletedSuccessfully = id == _clearAllGuid
-                ? _redirectRuleRepository.ClearAll()
-                : _redirectRuleRepository.Delete(id);
+            bool deletedSuccessfully;
+            
+            if (id == _clearAllGuid) {
+                deletedSuccessfully = _redirectRuleRepository.ClearAll();
+            } 
+            else if(id == _clearAllDuplicatesGuid) {
+                deletedSuccessfully = _redirectRuleRepository.RemoveAllDuplicates();
+            }
+            else {
+                deletedSuccessfully = _redirectRuleRepository.Delete(id);
+            }
             
             return deletedSuccessfully
                 ? Rest(HttpStatusCode.OK)

--- a/EpiserverRedirects/Repository/RedirectRuleCachedRepositoryDecorator.cs
+++ b/EpiserverRedirects/Repository/RedirectRuleCachedRepositoryDecorator.cs
@@ -45,6 +45,8 @@ namespace Forte.EpiserverRedirects.Repository
 
         public RedirectRule Update(RedirectRule redirectRule) => _redirectRuleRepository.Update(redirectRule);
 
+        public bool RemoveAllDuplicates() => _redirectRuleRepository.RemoveAllDuplicates();
+        
         public bool Delete(Guid id) => _redirectRuleRepository.Delete(id);
 
         public bool ClearAll() => _redirectRuleRepository.ClearAll();

--- a/EpiserverRedirects/Repository/Repository.cs
+++ b/EpiserverRedirects/Repository/Repository.cs
@@ -10,6 +10,7 @@ namespace Forte.EpiserverRedirects.Repository
         IQueryable<RedirectRule> GetAll();
         RedirectRule Add(RedirectRule redirectRule);
         RedirectRule Update(RedirectRule redirectRule);
+        bool RemoveAllDuplicates();
         bool Delete(Guid id);
         bool ClearAll();
     }
@@ -20,6 +21,7 @@ namespace Forte.EpiserverRedirects.Repository
         public abstract IQueryable<RedirectRule> GetAll();
         public abstract RedirectRule Add(RedirectRule redirectRule);
         public abstract RedirectRule Update(RedirectRule redirectRule);
+        public abstract bool RemoveAllDuplicates();
         public abstract bool Delete(Guid id);
         public abstract bool ClearAll();
 


### PR DESCRIPTION
We assume that **duplicate** is a redirect rule with the same **oldUrl** unless this rule RedirectRuleType is set to  **Regex**.

Old pattern | New pattern | Content Id | Redirect Rule Type |...| Created on| ... |
-- | -- | -- | -- | --|--|--|
/en/alloy-plan | /en/new-alloy-plan | -- | ExactMatch |--| 28-05-2021 11:07:55 | -- | 
/en/alloy-plan | /en/new-alloy-plan | -- | ExactMatch |--| 27-05-2021 11:07:55 | **treat as a duplicate** | 
/en/alloy-plan | /en/new-alloy | -- | ExactMatch |--| 26-05-2021 11:07:55 | **treat as a duplicate** | 
/en/alloy-plan | -- | 1001 | ExactMatch |--| 25-05-2021 11:07:55 |  **treat as a duplicate** | 
/en/alloy-plan-123 | /en/new-alloy-plan-123 | -- | ExactMatch | --| 24-05-2021 11:07:55
/en/alloy-plan-123 | /en/* | -- | Regex |--| 23-05-2021 11:07:55| **don't treat as a duplicate** |

Update behavior 
- During importing and adding redirect rules remove duplicate. 
- When adding duplicate: first add a new redirect rule then remove duplicates if exist.

New feature
- **Remove duplicates** button - will remove all duplicates 

![image](https://user-images.githubusercontent.com/8028139/119961350-3d5e5200-bfa6-11eb-970e-17e2e2c6b023.png)
