### PR TITLE
Removing AsEnumerable() call

### DIFF
--- a/EpiserverRedirects/Resolver/ExactMatchResolver.cs
+++ b/EpiserverRedirects/Resolver/ExactMatchResolver.cs
@@ -28,7 +28,6 @@ namespace Forte.EpiserverRedirects.Resolver
                     .GetAll()
                     .Where(r => r.IsActive && r.RedirectRuleType == RedirectRuleType.ExactMatch)
                     .OrderBy(x => x.Priority)
-                    .AsEnumerable()
                     .FirstOrDefault(r => r.OldPattern == encodedOldPath);
 
                 return ResolveRule(rule, r => new ExactMatchRedirect(r));


### PR DESCRIPTION
Removing AsEnumerable() call as this was causing high CPU usage. The whole collection was fetched from DB and then filtered in the memory instead of filtering on SQL level)