### PR TITLE
#65 Fix for adding redirect rules manually

### DIFF
--- a/EpiserverRedirects/Model/UrlPath.cs
+++ b/EpiserverRedirects/Model/UrlPath.cs
@@ -42,6 +42,11 @@ namespace Forte.EpiserverRedirects.Model
         {
             try
             {
+                if (string.IsNullOrEmpty(url))
+                {
+                    return url;
+                }
+                
                 var isAbsoluteUriParseOk = Uri.TryCreate(url.Trim(), UriKind.Absolute, out var uri);
                 var path = isAbsoluteUriParseOk ? uri.LocalPath : url;
                 var normalizedPath = NormalizePath(path);


### PR DESCRIPTION
it was impossible to add a rule with an empty "oldUrl" field