### PR TITLE
Reordered where clauses because ExactMatchResolver loaded too many ru…

### DIFF
--- a/EpiserverRedirects.EntityFramework.Tests/Repository/RedirectRulesRepositoryTest.cs
+++ b/EpiserverRedirects.EntityFramework.Tests/Repository/RedirectRulesRepositoryTest.cs
@@ -1,4 +1,6 @@
-﻿using Forte.EpiserverRedirects.EntityFramework;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Forte.EpiserverRedirects.EntityFramework.Model;
 using Forte.EpiserverRedirects.EntityFramework.Repository;
 using Forte.EpiserverRedirects.Model.RedirectRule;
@@ -7,13 +9,9 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Moq;
 using Moq.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
-
-namespace EpiserverRedirects.EntityFramework.Tests.Repository
+namespace Forte.EpiserverRedirects.EntityFramework.Tests.Repository
 {
     public class RedirectRulesRepositoryTest
     {

--- a/EpiserverRedirects.Tests/Unit/DynamicData/DynamicDataRepositoryTest.cs
+++ b/EpiserverRedirects.Tests/Unit/DynamicData/DynamicDataRepositoryTest.cs
@@ -1,14 +1,13 @@
-﻿using EPiServer.Data;
+﻿using System;
+using System.Linq;
+using EPiServer.Data;
 using Forte.EpiserverRedirects.DynamicData;
 using Forte.EpiserverRedirects.Model.RedirectRule;
 using Forte.EpiserverRedirects.Repository;
 using Moq;
-using System;
-using System.Linq;
 using Xunit;
 
-
-namespace Forte.EpiserverRedirects.Tests.Unit.DynamicDataStore
+namespace Forte.EpiserverRedirects.Tests.Unit.DynamicData
 {
     public class DynamicDataRepositoryTest
     {

--- a/EpiserverRedirects/Resolver/ExactMatchResolver.cs
+++ b/EpiserverRedirects/Resolver/ExactMatchResolver.cs
@@ -23,10 +23,10 @@ namespace Forte.EpiserverRedirects.Resolver
             var encodedOldPath = Uri.EscapeUriString(oldPath.ToString());
             var rule = _redirectRuleResolverRepository
                 .GetAll()
-                .Where(r => r.IsActive && r.RedirectRuleType == RedirectRuleType.ExactMatch)
+                .Where(r => r.IsActive && r.RedirectRuleType == RedirectRuleType.ExactMatch && r.OldPattern == encodedOldPath)
                 .OrderBy(x => x.Priority)
                 .AsEnumerable()
-                .FirstOrDefault(r => r.OldPattern == encodedOldPath);
+                .FirstOrDefault();
 
             var result = ResolveRule(rule, r => new ExactMatchRedirect(r));
             return Task.FromResult(result);


### PR DESCRIPTION
…les into memory