### PR TITLE
Add support of regex group to regex redirect type

### DIFF
--- a/EpiserverRedirects.Tests/Builder/Redirect/RedirectBuilder.cs
+++ b/EpiserverRedirects.Tests/Builder/Redirect/RedirectBuilder.cs
@@ -14,9 +14,15 @@ namespace Forte.EpiserverRedirects.Tests.Builder.Redirect
         private readonly RedirectRuleModel _redirectRule = new RedirectRuleModel();
         internal RedirectBuilder() { }
 
-        public RedirectBuilder WithHttpRequest(out Uri request, string requestPath)
+        public RedirectBuilder WithRelativeHttpRequest(out Uri request, string requestPath)
         {
-            request = HttpRequest(requestPath);
+            request = HttpRequest(requestPath, UriKind.Relative);
+            return this;
+        }
+        
+        public RedirectBuilder WithAbsoluteHttpRequest(out Uri request, string requestPath)
+        {
+            request = HttpRequest(requestPath, UriKind.Absolute);
             return this;
         }
         
@@ -36,7 +42,7 @@ namespace Forte.EpiserverRedirects.Tests.Builder.Redirect
             return this;
         }
 
-        private static Uri HttpRequest(string requestUrl) => new Uri(requestUrl, UriKind.Relative);
+        private static Uri HttpRequest(string requestUrl, UriKind uriKind) => new Uri(requestUrl, uriKind);
 
         public RedirectBuilder WithContentRedirectRule(out RedirectRuleModel redirectRule, int? contentReferenceId = null)
         {

--- a/EpiserverRedirects.Tests/Data/RandomDataGenerator.cs
+++ b/EpiserverRedirects.Tests/Data/RandomDataGenerator.cs
@@ -67,8 +67,13 @@ namespace Forte.EpiserverRedirects.Tests.Data
         
         private static string GetRandomDirectoryString(Random random)
         {
+            return GetRandomString(random, MaxLengthOfDirectory);
+        }
+
+        public static string GetRandomString(Random random, int characterAmount)
+        {
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-            return new string(Enumerable.Repeat(chars, random.Next(1, MaxLengthOfDirectory))
+            return new string(Enumerable.Repeat(chars, random.Next(1, characterAmount))
                 .Select(s => s[random.Next(s.Length)]).ToArray());
         }
     }

--- a/EpiserverRedirects.Tests/Unit/Extensions/RegexExtensionTests.cs
+++ b/EpiserverRedirects.Tests/Unit/Extensions/RegexExtensionTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Forte.EpiserverRedirects.Extensions;
+using Forte.EpiserverRedirects.Tests.Data;
+using Xunit;
+
+namespace Forte.EpiserverRedirects.Tests.Unit.Extensions;
+
+public class RegexExtensionTests
+{
+    [Fact]
+    public void Given_AnyString_AppendStartAndEndOfStringTokenToThePattern()
+    {
+        const int maxValue = 50;
+        var rnd = new Random();
+        var maxStringLength = rnd.Next(maxValue); 
+        var randomString = RandomDataGenerator.GetRandomString(rnd, maxStringLength);
+
+        var result = randomString.ToStrictRegexPattern();
+        
+        Assert.StartsWith("^", result);
+        Assert.EndsWith("$", result);
+    }
+}

--- a/EpiserverRedirects/Extensions/RegexExtension.cs
+++ b/EpiserverRedirects/Extensions/RegexExtension.cs
@@ -1,0 +1,9 @@
+namespace Forte.EpiserverRedirects.Extensions;
+
+public static class RegexExtension
+{
+    public static string ToStrictRegexPattern(this string originalPattern)
+    {
+        return $"^{originalPattern}$";
+    }
+}

--- a/EpiserverRedirects/Redirect/RegexRedirectRule.cs
+++ b/EpiserverRedirects/Redirect/RegexRedirectRule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text.RegularExpressions;
+using Forte.EpiserverRedirects.Extensions;
 using Forte.EpiserverRedirects.Model.RedirectRule;
 
 namespace Forte.EpiserverRedirects.Redirect
@@ -12,7 +13,7 @@ namespace Forte.EpiserverRedirects.Redirect
 
         protected override string GetPathWithoutContentId(Uri request, bool shouldPreserveQueryString)
         {
-            return Regex.Replace(request.ToString(), RedirectRule.OldPattern,
+            return Regex.Replace(request.AbsolutePath, RedirectRule.OldPattern.ToStrictRegexPattern(),
                 RedirectRule.NewPattern, RegexOptions.IgnoreCase);
         }
     }

--- a/EpiserverRedirects/Resolver/RegexResolver.cs
+++ b/EpiserverRedirects/Resolver/RegexResolver.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using EPiServer;
 using EPiServer.Web;
+using Forte.EpiserverRedirects.Extensions;
 using Forte.EpiserverRedirects.Model;
 using Forte.EpiserverRedirects.Model.RedirectRule;
 using Forte.EpiserverRedirects.Redirect;
@@ -30,8 +31,9 @@ namespace Forte.EpiserverRedirects.Resolver
                 .Where(r => r.IsActive && r.RedirectRuleType == RedirectRuleType.Regex)
                 .OrderBy(x => x.Priority)
                 .AsEnumerable()
-                .FirstOrDefault(r => Regex.IsMatch(encodedOldPath, r.OldPattern, RegexOptions.IgnoreCase));
-            var result = ResolveRule(rule, r => new ExactMatchRedirect(r));
+                .FirstOrDefault(r => Regex.IsMatch(encodedOldPath, Uri.UnescapeDataString(r.OldPattern).ToStrictRegexPattern(), RegexOptions.IgnoreCase));
+            
+            var result = ResolveRule(rule, r => new RegexRedirect(r));
             return Task.FromResult(result);
         }
     }


### PR DESCRIPTION
I saw that RegexResolver returned RegexRedirect, but it was changed over 4 years ago.

RegexRedirect (in RegexRedirectRule.cs) uses suggested solution actually.

I adapted current RegexRedirect and RegexResolver solution to check strict regex pattern for oldPattern value and replace it with correct newPattern.

It should work for both relative/the same host scenerio and absolute one.
