### PR TITLE
Update old pattern in Given_MatchingRule_Resolve_ReturnsTheRule test

### DIFF
--- a/EpiserverRedirects.Tests/Tests/Resolver/RegexTests.cs
+++ b/EpiserverRedirects.Tests/Tests/Resolver/RegexTests.cs
@@ -42,7 +42,7 @@ namespace Forte.EpiserverRedirects.Tests.Tests.Resolver
         {
             var resolver = RegexResolver()
                 .WithRandomExistingRules()
-                .WithRule(r=>r.WithOldPatternAndNewPattern("oldPattern", "newPattern/$1"), out var expectedRule)
+                .WithRule(r=>r.WithOldPatternAndNewPattern("/oldPattern", "newPattern/$1"), out var expectedRule)
                 .Create();
             
             var redirect = await resolver.ResolveRedirectRuleAsync(UrlPath.Parse("/oldPattern"));


### PR DESCRIPTION
When I updated regex redirect rule I missed one not-passing test which used wrong old pattern (not corresponding to current saving old pattern logic which normalize this pattern).