### PR TITLE
Use HTTPS Optimizely NuGet source

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="EPiServer" value="http://nuget.episerver.com/feed/packages.svc/" />
+    <add key="Optimizely" value="https://api.nuget.optimizely.com/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
The latest build pipeline failed because of this error https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1302

The PR changes Optimizely NuGet source from HTTP to HTTPS