### PR TITLE
Import content provider from CSV

### DIFF
--- a/EpiserverRedirects/Configuration/ContentProvidersOptions.cs
+++ b/EpiserverRedirects/Configuration/ContentProvidersOptions.cs
@@ -22,14 +22,22 @@ public class ContentProvidersOptions
     {
         if (providerKey?.ToLower() == ContentProviderConstants.AllKey || providerKey == string.Empty) return ContentProviderConstants.AllId;
         
-        var contentProviderOption = GetContentProviderOption(providerKey);
+        var contentProviderOption = GetContentProviderOptionByKey(providerKey);
             
         return contentProviderOption.Id;
     }
     
-    public ContentProviderOption GetContentProviderOption(string providerKey)
+    public ContentProviderOption GetContentProviderOptionByKey(string providerKey)
     {
         var contentProviderOption = ContentProviders.FirstOrDefault(cp => cp.Key == providerKey) 
+                                    ?? GetDefaultContentProviderOption();
+            
+        return contentProviderOption;
+    }
+    
+    public ContentProviderOption GetContentProviderOptionByName(string name)
+    {
+        var contentProviderOption = ContentProviders.FirstOrDefault(cp => cp.Name == name) 
                                     ?? GetDefaultContentProviderOption();
             
         return contentProviderOption;

--- a/EpiserverRedirects/Configuration/ContentProvidersOptions.cs
+++ b/EpiserverRedirects/Configuration/ContentProvidersOptions.cs
@@ -37,7 +37,7 @@ public class ContentProvidersOptions
     
     public ContentProviderOption GetContentProviderOptionByName(string name)
     {
-        var contentProviderOption = ContentProviders.FirstOrDefault(cp => cp.Name == name) 
+        var contentProviderOption = ContentProviders.FirstOrDefault(cp => cp.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase)) 
                                     ?? GetDefaultContentProviderOption();
             
         return contentProviderOption;

--- a/EpiserverRedirects/Configuration/ContentProvidersOptions.cs
+++ b/EpiserverRedirects/Configuration/ContentProvidersOptions.cs
@@ -22,10 +22,17 @@ public class ContentProvidersOptions
     {
         if (providerKey?.ToLower() == ContentProviderConstants.AllKey || providerKey == string.Empty) return ContentProviderConstants.AllId;
         
+        var contentProviderOption = GetContentProviderOption(providerKey);
+            
+        return contentProviderOption.Id;
+    }
+    
+    public ContentProviderOption GetContentProviderOption(string providerKey)
+    {
         var contentProviderOption = ContentProviders.FirstOrDefault(cp => cp.Key == providerKey) 
                                     ?? GetDefaultContentProviderOption();
             
-        return contentProviderOption.Id;
+        return contentProviderOption;
     }
     
 

--- a/EpiserverRedirects/Export/ExportRedirectsController.cs
+++ b/EpiserverRedirects/Export/ExportRedirectsController.cs
@@ -11,6 +11,7 @@ using Forte.EpiserverRedirects.Model.RedirectRule;
 using Forte.EpiserverRedirects.Repository;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Forte.EpiserverRedirects.Export
 {
@@ -19,11 +20,13 @@ namespace Forte.EpiserverRedirects.Export
     {
         private readonly IRedirectRuleRepository _redirectRuleRepository;
         private readonly IMimeTypeResolver _mimeTypeResolver;
+        private readonly IOptions<ContentProvidersOptions> _contentProvidersOptions;
 
-        public ExportRedirectsController(IRedirectRuleRepository redirectRuleRepository, IMimeTypeResolver mimeTypeResolver)
+        public ExportRedirectsController(IRedirectRuleRepository redirectRuleRepository, IMimeTypeResolver mimeTypeResolver, IOptions<ContentProvidersOptions> contentProvidersOptions)
         {
             _redirectRuleRepository = redirectRuleRepository;
             _mimeTypeResolver = mimeTypeResolver;
+            _contentProvidersOptions = contentProvidersOptions;
         }
 
         [HttpGet]
@@ -59,7 +62,8 @@ namespace Forte.EpiserverRedirects.Export
                 {
                     var redirectRules = _redirectRuleRepository
                         .GetAll()
-                        .Select(RedirectRuleExportRow.CreateFromRedirectRule);
+                        .ToArray()
+                        .Select(x => RedirectRuleExportRow.CreateFromRedirectRule(x, _contentProvidersOptions.Value));
 
                     csvWriter.WriteRecords(redirectRules);
                 }

--- a/EpiserverRedirects/Import/RedirectsImporter.cs
+++ b/EpiserverRedirects/Import/RedirectsImporter.cs
@@ -6,6 +6,7 @@ using EPiServer.Web;
 using Forte.EpiserverRedirects.Configuration;
 using Forte.EpiserverRedirects.Model.RedirectRule;
 using Forte.EpiserverRedirects.Repository;
+using Microsoft.Extensions.Options;
 
 namespace Forte.EpiserverRedirects.Import
 {
@@ -13,12 +14,14 @@ namespace Forte.EpiserverRedirects.Import
     {
         private readonly IRedirectRuleRepository _redirectRuleRepository;
         private readonly RedirectsOptions _options;
+        private readonly IOptions<ContentProvidersOptions> _contentProvidersOptions;
         private readonly Lazy<IEnumerable<SiteDefinition>> _allHosts;
 
-        public RedirectsImporter(IRedirectRuleRepository redirectRuleRepository, RedirectsOptions options, ISiteDefinitionRepository siteDefinitionRepository)
+        public RedirectsImporter(IRedirectRuleRepository redirectRuleRepository, RedirectsOptions options, ISiteDefinitionRepository siteDefinitionRepository, IOptions<ContentProvidersOptions> contentProvidersOptions)
         {
             _redirectRuleRepository = redirectRuleRepository;
             _options = options;
+            _contentProvidersOptions = contentProvidersOptions;
             _allHosts = new Lazy<IEnumerable<SiteDefinition>>(siteDefinitionRepository.List());
         }
         public void ImportRedirects(IEnumerable<RedirectRuleImportRow> redirectsToImport)
@@ -38,6 +41,7 @@ namespace Forte.EpiserverRedirects.Import
                     redirectRow.Notes,
                     redirectRow.Priority ?? _options.DefaultRedirectRulePriority, DetermineHostId(redirectRow.Host))
                 : RedirectRuleModel.NewFromImport(redirectRow.OldPattern, redirectRow.ContentId.Value,
+                    Parser.ParseContentProviderKey(redirectRow.ContentProviderName, _contentProvidersOptions.Value),
                     Parser.ParseRedirectType(redirectRow.RedirectType),
                     Parser.ParseRedirectRuleType(redirectRow.RedirectRuleType),
                     Parser.ParseBoolean(redirectRow.IsActive),

--- a/EpiserverRedirects/Model/RedirectRule/Parser.cs
+++ b/EpiserverRedirects/Model/RedirectRule/Parser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using EPiServer.Shell.Services.Rest;
+using Forte.EpiserverRedirects.Configuration;
 using Forte.EpiserverRedirects.Menu;
 using Forte.EpiserverRedirects.Menu.ContentProviders;
 
@@ -98,6 +99,11 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
             }
 
             return null;
+        }
+
+        public static string ParseContentProviderKey(string contentProviderName, ContentProvidersOptions options)
+        {
+            return options.GetContentProviderOptionByName(contentProviderName).Key;
         }
 
         public static IEnumerable<SortColumn> ParseSortColumns(string sortQuery)

--- a/EpiserverRedirects/Model/RedirectRule/RedirectRuleExportRow.cs
+++ b/EpiserverRedirects/Model/RedirectRule/RedirectRuleExportRow.cs
@@ -63,7 +63,7 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
                 CreatedBy = redirectRule.CreatedBy,
                 Notes = redirectRule.Notes,
                 Host = redirectRule.HostId,
-                ContentProvider = contentProvidersOptions.GetContentProviderOption(redirectRule.ContentProviderKey).Name,
+                ContentProvider = contentProvidersOptions.GetContentProviderOptionByKey(redirectRule.ContentProviderKey).Name,
             };
         }
     }

--- a/EpiserverRedirects/Model/RedirectRule/RedirectRuleExportRow.cs
+++ b/EpiserverRedirects/Model/RedirectRule/RedirectRuleExportRow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CsvHelper.Configuration.Attributes;
+using Forte.EpiserverRedirects.Configuration;
 
 namespace Forte.EpiserverRedirects.Model.RedirectRule
 {
@@ -41,7 +42,12 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
         [Index(11), Optional]
         public Guid? Host { get; set; }
         
-        public static RedirectRuleExportRow CreateFromRedirectRule(IRedirectRule redirectRule)
+        [Index(12)]
+        public string ContentProvider { get; set; }
+        
+        public static RedirectRuleExportRow CreateFromRedirectRule(
+            IRedirectRule redirectRule,
+            ContentProvidersOptions contentProvidersOptions)
         {
             return new RedirectRuleExportRow
             {
@@ -56,7 +62,8 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
                 CreatedOn = redirectRule.CreatedOn.ToString("dd/MM/yyyy H:mm:ss"),
                 CreatedBy = redirectRule.CreatedBy,
                 Notes = redirectRule.Notes,
-                Host = redirectRule.HostId
+                Host = redirectRule.HostId,
+                ContentProvider = contentProvidersOptions.GetContentProviderOption(redirectRule.ContentProviderKey).Name,
             };
         }
     }

--- a/EpiserverRedirects/Model/RedirectRule/RedirectRuleImportRow.cs
+++ b/EpiserverRedirects/Model/RedirectRule/RedirectRuleImportRow.cs
@@ -34,6 +34,9 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
         [Index(8), Optional]
         public string Host { get; set; }
 
+        [Index(9)]
+        public string ContentProviderName { get; set; }
+
         public static string[] FieldNames => typeof(RedirectRuleImportRow).GetProperties().Where(
                 prop => Attribute.IsDefined(prop, typeof(IndexAttribute)))
             .OrderBy(property => property

--- a/EpiserverRedirects/Model/RedirectRule/RedirectRuleModel.cs
+++ b/EpiserverRedirects/Model/RedirectRule/RedirectRuleModel.cs
@@ -101,7 +101,7 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
             };
         }
 
-        public static RedirectRuleModel NewFromImport(string oldPattern, int contentId, RedirectType redirectType,
+        public static RedirectRuleModel NewFromImport(string oldPattern, int contentId, string contentProviderKey, RedirectType redirectType,
             RedirectRuleType redirectRuleType, bool isActive, string notes, int priority, Guid? hostId)
         {
             return new RedirectRuleModel
@@ -109,6 +109,7 @@ namespace Forte.EpiserverRedirects.Model.RedirectRule
                 RedirectOrigin = RedirectOrigin.Import,
                 OldPattern = UrlPath.ExtractRelativePath(oldPattern),
                 ContentId = contentId,
+                ContentProviderKey = contentProviderKey,
                 RedirectType = redirectType,
                 RedirectRuleType = redirectRuleType,
                 IsActive = isActive,


### PR DESCRIPTION
This PR updates importing and exporting content provider redirect's information from/to CSV file.

I notice problematic issues how we process CSV in both scenarios. I don't know why we don't define header row for both files which would simplify importing for user without wondering on which column we expect data is.

For now I chose the simplest way and won't introduce any breaking changes regarding importing.